### PR TITLE
push to shopify gem repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in viking.gemspec
 gemspec
+
+group :deployment do
+  gem 'package_cloud'
+  gem 'rake'
+end

--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ hdfs classes.
       Viking::Dir.mkdir(path)
     end
 
+Releasing a new version
+-----------------------
+
+1. Update the version in `version.rb`
+2. Commit this to master
+3. Tag the commit with `git tag <version>` from (1) and run `git push --tags`
+4. Go to [Shipit](https://shipit.shopify.io/shopify/Viking/production) and click deploy on the respective commit
+
+Installation
+---
+
+```ruby
+source 'https://packages.shopify.io/shopify/gems' do
+  gem 'hdfs-viking'
+end
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 #!/usr/bin/env rake
 
 require 'rake/testtask'
+require "bundler/gem_tasks"
 
 Rake::TestTask.new do |t|
   t.libs << 'lib/viking'

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+  override:
+    - bundle exec rake build
+    - bundle exec package_cloud push shopify/gems pkg/*.gem


### PR DESCRIPTION
Migrate Viking to out private Shopify gem repository. Support for git-sourced gems is being phased out.

Once merged the following needs to be done,
- [x] Tag this commit as version 0.0.8
- [ ] Go to [Shipit](https://shipit.shopify.io/shopify/Viking/production) and click deploy on this commit

This is based on [this document.](https://dev-accel.shopify.io/guides/package_cloud_gems)
Issue: https://github.com/Shopify/longboat/issues/2725